### PR TITLE
Fix typo for publishing assets under tag 'tables'

### DIFF
--- a/src/AppServiceProvider.php
+++ b/src/AppServiceProvider.php
@@ -35,7 +35,7 @@ class AppServiceProvider extends ServiceProvider
         ], 'enso-assets');
 
         $this->publishes([
-            __DIR__.'/app/Tabels' => app_path('Tables'),
+            __DIR__.'/app/Tables' => app_path('Tables'),
         ], 'tables');
 
         $this->publishes([


### PR DESCRIPTION
Came across a typo when publishing all assets from package service provider.