### PR TITLE
fixing output of counted results if filters enabled

### DIFF
--- a/src/app/Classes/Table/Builder.php
+++ b/src/app/Classes/Table/Builder.php
@@ -53,7 +53,7 @@ class Builder
         $this->checkActions();
 
         return [
-            'count' => $this->count,
+            'count' => $this->count(),
             'filtered' => $this->filtered,
             'total' => $this->total,
             'data' => $this->data,


### PR DESCRIPTION
Function **run()** launches functions: _sort(), limit()_ that can modify class attribute **$this->count** of total results and we store class attribute  **$this->count** before launching functions listed above.
```
private function run()
{
    $this->filtered = $this->count = $this->count();

    $this->setDetailedInfo()
        ->filter()
        ->sort()
        ->setTotal()
        ->limit()
        ->setData()
        ->setAppends()
        ->toArray()
        ->computeEnum()
        ->computeDate();
}
```
Because of that: we got fake count number of results with filters enabled in some cases.
My suggestion is to count query again, before we give back results.