### PR TITLE
Ajax POST support and add keys to request when params specified

### DIFF
--- a/src/app/Classes/Template/Builders/Buttons.php
+++ b/src/app/Classes/Template/Builders/Buttons.php
@@ -60,7 +60,7 @@ class Buttons
         }
 
         if (collect(self::PathActions)->contains($button->action)) {
-            $button->path = route($route, [$type === 'row' ? 'dtRowId' : null], false);
+            $button->path = route($route, $type === 'row' ? isset($button->params) ? json_decode(json_encode($button->params), true) : ['dtRowId'] : null, false);
 
             return false;
         }

--- a/src/resources/assets/js/components/enso/vuedatatable/TableBody.vue
+++ b/src/resources/assets/js/components/enso/vuedatatable/TableBody.vue
@@ -201,7 +201,7 @@ export default {
             }
 
             if (button.action === 'ajax') {
-                this.$emit('ajax', button.method, this.getPath(button, row.dtRowId), button.postEvent);
+                this.$emit('ajax', button.method, this.getPath(button, row.dtRowId), this.getRouteParams(button, row), button.postEvent);
                 return;
             }
 

--- a/src/resources/assets/js/components/enso/vuedatatable/VueTable.vue
+++ b/src/resources/assets/js/components/enso/vuedatatable/VueTable.vue
@@ -439,14 +439,22 @@ export default {
                 ? { params }
                 : params;
         },
-        ajax(method, path, postEvent) {
-            axios[method.toLowerCase()](path).then(({ data }) => {
-                this.$toastr.success(data.message);
-                this.getData();
-                if (postEvent) {
-                    this.$emit(postEvent);
-                }
-            }).catch(error => this.handleError(error));
+        ajax(method, path, params, postEvent) {
+          let args = [];
+          if (method === 'POST') {
+            args.push(this.stripPathParams(path));
+            args.push(params);
+          } else {
+            args.push(path);
+          }
+
+          axios[method.toLowerCase()](...args).then(({ data }) => {
+            this.$toastr.success(data.message);
+            this.getData();
+            if (postEvent) {
+              this.$emit(postEvent);
+            }
+          }).catch(error => this.handleError(error));
         },
         action(method, path, postEvent) {
             this.loading = true;
@@ -459,6 +467,9 @@ export default {
                         this.$emit(postEvent);
                     }
                 }).catch(error => this.handleError(error));
+        },
+        stripPathParams(path) {
+            return path.substring(0, path.indexOf('?')).replace('?', '');
         },
         filterUpdate() {
             if (!this.initialised) {

--- a/src/resources/assets/js/components/enso/vuedatatable/VueTable.vue
+++ b/src/resources/assets/js/components/enso/vuedatatable/VueTable.vue
@@ -440,21 +440,21 @@ export default {
                 : params;
         },
         ajax(method, path, params, postEvent) {
-          let args = [];
-          if (method === 'POST') {
-            args.push(this.stripPathParams(path));
-            args.push(params);
-          } else {
-            args.push(path);
-          }
-
-          axios[method.toLowerCase()](...args).then(({ data }) => {
-            this.$toastr.success(data.message);
-            this.getData();
-            if (postEvent) {
-              this.$emit(postEvent);
+            let args = [];
+            if (method === 'POST') {
+                args.push(this.stripPathParams(path));
+                args.push(params);
+            } else {
+                args.push(path);
             }
-          }).catch(error => this.handleError(error));
+
+            axios[method.toLowerCase()](...args).then(({ data }) => {
+                this.$toastr.success(data.message);
+                this.getData();
+                if (postEvent) {
+                this.$emit(postEvent);
+                }
+            }).catch(error => this.handleError(error));
         },
         action(method, path, postEvent) {
             this.loading = true;


### PR DESCRIPTION
I hit some issues sending Ajax post requests from buttons in the table row, even when using POST it was forming the request like this: `/admin/customer/delete?7`

Also, when sending a GET/DELETE request I needed the URI formed like `/admin/customer/delete?id=7`

I have made a few of changes, which I believe should not break anything!:

- Modified the way `$button->path` is formed, it will now check if `params` has been defined for the row button in the template, if it has it will use them in forming the route. This is great when defining a route like `Route::get('/delete/{id}')->name('route.name');` as it will place `dtRowId` wherever `{id}` has been defined. Otherwise it will form it like `/admin/customers/delete?id=dtRowId`. If no `params` object has been defined it will form it like it does currently `/admin/customers/delete?dtRowId`.

- Altered the ajax event to also emit the route parameters, these will only be used if using the `POST` method.

- `ajax` method now checks if the method is a `POST` and will pass two arguments to the axios function, stripping parameters from the request URI.

Let me know what you think :)


