### PR TITLE
Selectable row support

### DIFF
--- a/src/app/Classes/Attributes/Structure.php
+++ b/src/app/Classes/Attributes/Structure.php
@@ -7,6 +7,6 @@ class Structure
     const Mandatory = ['routePrefix', 'readSuffix', 'columns'];
 
     const Optional = [
-        'crtNo', 'appends', 'buttons', 'lengthMenu', 'auth', 'debounce', 'method',
+        'crtNo', 'appends', 'buttons', 'lengthMenu', 'auth', 'debounce', 'method', 'selectable'
     ];
 }

--- a/src/app/Classes/Template/Validators/Structure.php
+++ b/src/app/Classes/Template/Validators/Structure.php
@@ -73,5 +73,9 @@ class Structure
             && !collect(['GET', 'POST'])->contains($this->template->method)) {
             throw new TemplateException(__('"method" attribute can be either "GET" or "POST"'));
         }
+
+        if (property_exists($this->template, 'selectable') && !is_bool($this->template->selectable)) {
+            throw new TemplateException(__('"selectable" attribute must be a boolean'));
+        }
     }
 }

--- a/src/app/Tables/Templates/template.json
+++ b/src/app/Tables/Templates/template.json
@@ -7,6 +7,7 @@
     "debounce": 100, //optional, the debounce ms limit for reloading table data
     "lengthMenu": [10, 15, 20, 25, 30], //optional, table pagination options. If given, it overwrites the value from config
     "appends": ["customAttribute"], // optional, laravel model accessors for custom attributes
+    "selectable": false, //optional, adds checkboxes to first column
     "buttons": [
         "show", "create", "edit", "destroy", "download", "exportExcel", // string buttons must match the config
         {

--- a/src/resources/assets/js/components/enso/vuedatatable/TableBody.vue
+++ b/src/resources/assets/js/components/enso/vuedatatable/TableBody.vue
@@ -4,6 +4,23 @@
     <tr v-for="(row, index) in body.data"
         :key="index">
         <td :class="template.align"
+            v-if="template.selectable && selectable && !isChild(row)">
+            <div class="selectable">
+                <span class="selectable-input">
+                    <label class="form-checkbox">
+    					<input type="checkbox" :value="row.dtRowId" v-model="selected">
+  					</label>
+                </span>
+                <span class="hidden-controls"
+                      v-if="hiddenCount"
+                      @click="toggleExpand(row, index)">
+                    <span class="icon is-small">
+                        <fa :icon="isExpanded(row) ? 'minus-square' : 'plus-square'"/>
+                    </span>
+                </span>
+            </div>
+        </td>
+        <td :class="template.align"
             v-if="template.crtNo && !isChild(row)">
             <div class="crt-no">
                 <span class="crt-no-label">
@@ -140,6 +157,10 @@ export default {
             type: Array,
             required: true,
         },
+        selectable: {
+          type: Boolean,
+          required: true
+        },
     },
 
     data() {
@@ -147,7 +168,16 @@ export default {
             modal: false,
             row: null,
             button: null,
+            selected: [],
+            selectAll: false
         };
+    },
+
+    mounted() {
+        this.$root.$on('dtSelectAllRows', data => {
+          this.selected = data.selected;
+          this.selectAll = data.selectAll
+        })
     },
 
     computed: {
@@ -179,6 +209,11 @@ export default {
                 this.refreshExpanded();
             },
         },
+        selected: {
+          handler(selected) {
+            this.$emit('selected', selected)
+          }
+        }
     },
 
     methods: {

--- a/src/resources/assets/js/components/enso/vuedatatable/TableHeader.vue
+++ b/src/resources/assets/js/components/enso/vuedatatable/TableHeader.vue
@@ -3,6 +3,12 @@
     <thead>
         <tr :class="['has-background-light', template.style]">
             <th :class="['vue-table-header', template.align]"
+                v-if="template.selectable && selectable">
+                <label class="form-checkbox">
+                    <input type="checkbox" v-model="selectAll" @click="selectAllRows">
+                </label>
+            </th>
+            <th :class="['vue-table-header', template.align]"
                 v-if="template.crtNo">
                 {{ i18n(template.labels.crtNo) }}
             </th>
@@ -70,10 +76,25 @@ export default {
             type: Object,
             required: true,
         },
+        body: {
+          type: Object,
+          required: true
+        },
+        selectable: {
+          type: Boolean,
+          required: true
+        },
         i18n: {
             type: Function,
             required: true,
         },
+    },
+
+    data() {
+      return {
+        selected: [],
+        selectAll: false
+      }
     },
 
     methods: {
@@ -108,6 +129,23 @@ export default {
             this.template.columns.forEach(({ meta }) => {
                 meta.sort = null;
             });
+        },
+        isChild(row) {
+          return Array.isArray(row);
+        },
+        selectAllRows() {
+          this.selected = [];
+          if (!this.selectAll && Array.isArray(this.body.data)) {
+            this.body.data.forEach(row => {
+              if (!this.isChild(row)) {
+                this.selected.push(row.dtRowId)
+              }
+            });
+          }
+          this.$root.$emit('dtSelectAllRows', {
+            selected: this.selected,
+            selectAll: this.selectAll
+          })
         },
     },
 };

--- a/src/resources/assets/js/components/enso/vuedatatable/VueTable.vue
+++ b/src/resources/assets/js/components/enso/vuedatatable/VueTable.vue
@@ -21,15 +21,20 @@
                 :class="template.style"
                 id="id">
                 <table-header :template="template"
+                    :body="body"
                     :i18n="i18n"
-                    @sort-update="getData"/>
+                    :selectable="selectable"
+                    @sort-update="getData"
+                    v-if="hasContent" />
                 <table-body :template="template"
                     v-on="$listeners"
                     :body="body"
                     :start="start"
                     :i18n="i18n"
                     :expanded="expanded"
+                    :selectable="selectable"
                     @ajax="ajax"
+                    @selected="updateSelected"
                     v-if="hasContent">
                     <template v-for="column in template.columns"
                         :slot="column.name"
@@ -120,6 +125,10 @@ export default {
             type: Object,
             default: null,
         },
+        selectable: {
+            type: Boolean,
+            default: true
+        },
         i18n: {
             type: Function,
             default(key) {
@@ -142,6 +151,7 @@ export default {
             length: null,
             expanded: [],
             forceInfo: false,
+            selected: []
         };
     },
 
@@ -163,6 +173,7 @@ export default {
                 template: {
                     sort: this.template.sort,
                     style: this.template.style,
+                    selectable: this.template.selectable
                 },
                 columns: this.template.columns
                     .reduce((collector, column) => {
@@ -350,6 +361,7 @@ export default {
                 filters: this.filters,
                 intervals: this.intervals,
                 params: this.params,
+                selected: this.selected
             };
 
             method = method || this.template.method;
@@ -462,6 +474,9 @@ export default {
             this.start = 0;
             this.getData();
         },
+        updateSelected(selected) {
+            this.selected = selected
+        }
     },
 };
 


### PR DESCRIPTION
This is  a **feature request**.

### Prerequisites
* [✅] Are you running the latest version?
* [✅] Are you reporting to the correct repository?
* [✅] Did you check the documentation?
* [✅] Did you perform a cursory search?

### Description
I have a need for selectable rows on the table, to put into context, I need to create a group of resources and to do this I need to search the data to easily add the resources needed. This PR adds a new optional `selectable` option to the template and when `true` it will add a column at the start of the table with checkboxes, including a checkbox in the header to select all rows.

To send this data to the backend I would define a global button using the `ajax` action. I have updated the `readRequest` method to also pass the `selected` array in the request.

But how do I associate the selected resources with the group? for this I would pass additional `params` via the prop:

Using Vue:
```
    <vue-table class="vue-table px-6 pb-6"
               path="{!! route('admin.group.table.init') !!}"
               id="group-table"
               :params="{ group: groupId }"
    ></vue-table>
```

Passing via blade:
```
    <vue-table class="vue-table px-6 pb-6"
               path="{!! route('admin.customers.table.init') !!}"
               id="customers-table"
               :params="{ group: {!! $groupId !!} }"
    ></vue-table>
```

Now I have everything I need on the backend to create the group :)

I've also added a `selectable` prop to the `VueTable`, this allows for the checkboxes to be disabled if needed without altering the template (you may need two tables using the same template, but only one with checkboxes)
