### PR TITLE
Select all button added to topControls & isSelected action helper

### DIFF
--- a/src/app/Classes/Action.php
+++ b/src/app/Classes/Action.php
@@ -48,6 +48,15 @@ abstract class Action
         return $this->data;
     }
 
+    public function isSelected(int $dtRowId)
+    {
+        if (in_array($dtRowId, $this->request->selected)) {
+            return true;
+        }
+
+        return false;
+    }
+
     private function next()
     {
         $this->data = $this->builder
@@ -60,14 +69,5 @@ abstract class Action
     {
         $this->builder = (new $this->class($this->request))
             ->fetcher($this->chunk);
-    }
-
-    private function isSelected(int $dtRowId)
-    {
-        if (in_array($dtRowId, $this->request->selected)) {
-            return true;
-        }
-
-        return false;
     }
 }

--- a/src/app/Classes/Action.php
+++ b/src/app/Classes/Action.php
@@ -61,4 +61,13 @@ abstract class Action
         $this->builder = (new $this->class($this->request))
             ->fetcher($this->chunk);
     }
+
+    private function isSelected(int $dtRowId)
+    {
+        if (in_array($dtRowId, $this->request->selected)) {
+            return true;
+        }
+
+        return false;
+    }
 }

--- a/src/app/Classes/Table/Builder.php
+++ b/src/app/Classes/Table/Builder.php
@@ -167,7 +167,6 @@ class Builder
         return $this;
     }
 
-
     private function setRaw()
     {
         $this->raw = $this->query->get();

--- a/src/app/Classes/Table/Builder.php
+++ b/src/app/Classes/Table/Builder.php
@@ -131,8 +131,6 @@ class Builder
             }
         }
 
-        $this->setRaw();
-
         return $this;
     }
 
@@ -182,7 +180,7 @@ class Builder
         if ($this->fullRecordInfo && $this->selectable) {
             $this->setRaw();
         }
-        
+
         $this->query->skip($this->meta->start)
             ->take($this->meta->length);
 

--- a/src/resources/assets/js/components/enso/vuedatatable/TableBody.vue
+++ b/src/resources/assets/js/components/enso/vuedatatable/TableBody.vue
@@ -151,10 +151,6 @@ export default {
             type: Array,
             required: true,
         },
-        selected: {
-            type: Array,
-            required: true,
-        },
     },
 
     data() {
@@ -294,15 +290,15 @@ export default {
         selectPage(status) {
             this.body.data.forEach((row) => {
                 if (!this.isChild(row)) {
-                    const index = this.selected.findIndex(id => id === row.dtRowId);
+                    const index = this.$parent.selected.findIndex(id => id === row.dtRowId);
 
                     if (status && index === -1) {
-                        this.selected.push(row.dtRowId);
+                        this.$parent.selected.push(row.dtRowId);
                         return;
                     }
 
                     if (!status) {
-                        this.selected.splice(index, 1);
+                        this.$parent.selected.splice(index, 1);
                     }
                 }
             });
@@ -310,7 +306,7 @@ export default {
             this.updateSelected();
         },
         updateSelected() {
-            this.$emit('update-selected', this.selected);
+            this.$emit('update-selected', this.$parent.selected);
         },
     },
 };

--- a/src/resources/assets/js/components/enso/vuedatatable/TableHeader.vue
+++ b/src/resources/assets/js/components/enso/vuedatatable/TableHeader.vue
@@ -85,6 +85,7 @@ export default {
 
     data() {
         return {
+            allSelected: false,
             pageSelected: false,
         };
     },
@@ -123,6 +124,9 @@ export default {
             this.template.columns.forEach(({ meta }) => {
                 meta.sort = null;
             });
+        },
+        updateAllSelectedFlag(state) {
+            this.allSelected = state;
         },
         updateSelectedFlag(state) {
             this.pageSelected = state;

--- a/src/resources/assets/js/components/enso/vuedatatable/TopControls.vue
+++ b/src/resources/assets/js/components/enso/vuedatatable/TopControls.vue
@@ -14,6 +14,9 @@
                     v-on="$listeners"/>
                 <style-selector :template="template"
                     class="is-hidden-mobile"/>
+                <select-all
+                    v-if="info && template.selectable"
+                    v-on="$listeners"/>
                 <button class="button"
                     @click="$emit('reload')">
                     <span class="icon is-small">
@@ -89,6 +92,7 @@ import { faSync, faUndo, faSearch, faInfoCircle } from '@fortawesome/free-solid-
 import LengthMenu from './topControls/LengthMenu.vue';
 import ColumnVisibility from './topControls/ColumnVisibility.vue';
 import StyleSelector from './topControls/StyleSelector.vue';
+import SelectAll from './topControls/SelectAll.vue';
 import Modal from './Modal.vue';
 
 library.add(faSync, faUndo, faSearch, faInfoCircle);
@@ -97,7 +101,7 @@ export default {
     name: 'TopControls',
 
     components: {
-        LengthMenu, ColumnVisibility, StyleSelector, Modal,
+        LengthMenu, ColumnVisibility, StyleSelector, SelectAll, Modal,
     },
 
     props: {

--- a/src/resources/assets/js/components/enso/vuedatatable/TopControls.vue
+++ b/src/resources/assets/js/components/enso/vuedatatable/TopControls.vue
@@ -15,7 +15,7 @@
                 <style-selector :template="template"
                     class="is-hidden-mobile"/>
                 <select-all
-                    v-if="info && template.selectable"
+                    v-if="!info && template.selectable"
                     v-on="$listeners"/>
                 <button class="button"
                     @click="$emit('reload')">

--- a/src/resources/assets/js/components/enso/vuedatatable/VueTable.vue
+++ b/src/resources/assets/js/components/enso/vuedatatable/VueTable.vue
@@ -128,7 +128,7 @@ export default {
         },
         select: {
             type: Array,
-            default: []
+            default: () => []
         },
         i18n: {
             type: Function,

--- a/src/resources/assets/js/components/enso/vuedatatable/VueTable.vue
+++ b/src/resources/assets/js/components/enso/vuedatatable/VueTable.vue
@@ -437,6 +437,7 @@ export default {
                 filters: this.filters,
                 intervals: this.intervals,
                 params: this.params,
+                selected: this.selected
             };
 
             return this.template.method === 'GET'

--- a/src/resources/assets/js/components/enso/vuedatatable/VueTable.vue
+++ b/src/resources/assets/js/components/enso/vuedatatable/VueTable.vue
@@ -126,6 +126,10 @@ export default {
             type: Object,
             default: null,
         },
+        select: {
+            type: Array,
+            default: []
+        },
         i18n: {
             type: Function,
             default(key) {
@@ -331,6 +335,7 @@ export default {
                     ? this.processMoney(data)
                     : data;
 
+                this.selected = this.select;
                 this.$nextTick(() => this.updateSelectedFlag());
 
                 this.$emit('draw');

--- a/src/resources/assets/js/components/enso/vuedatatable/VueTable.vue
+++ b/src/resources/assets/js/components/enso/vuedatatable/VueTable.vue
@@ -10,6 +10,7 @@
             @update-length="length=$event"
             @export-data="exportData"
             @action="action"
+            @select-all="selectAll"
             @reload="getData()"
             @reset="resetPreferences"
             @request-full-info="forceInfo = true; getData()"
@@ -32,7 +33,6 @@
                     :start="start"
                     :i18n="i18n"
                     :expanded="expanded"
-                    :selected="selected"
                     @ajax="ajax"
                     @update-selected="updateSelectedFlag()"
                     ref="body"
@@ -474,6 +474,34 @@ export default {
         },
         selectPage(state) {
             this.$refs.body.selectPage(state);
+        },
+        selectAll(status) {
+            this.body.raw.forEach((row) => {
+                if (!this.$refs.body.isChild(row)) {
+                    const index = this.selected.findIndex(id => id === row.dtRowId);
+
+                    if (status && index === -1) {
+                        this.selected.push(row.dtRowId);
+                        return;
+                    }
+
+                    if (!status) {
+                        this.selected = [];
+                    }
+                }
+            });
+
+            this.$refs.body.updateSelected();
+            this.updateAllSelectedFlag();
+        },
+        updateAllSelectedFlag() {
+            if (!this.$refs.header) {
+                return;
+            }
+
+            const selected = this.body.raw.length === this.selected.length;
+
+            this.$refs.header.updateAllSelectedFlag(selected);
         },
         updateSelectedFlag() {
             if (!this.$refs.header) {

--- a/src/resources/assets/js/components/enso/vuedatatable/VueTable.vue
+++ b/src/resources/assets/js/components/enso/vuedatatable/VueTable.vue
@@ -357,6 +357,7 @@ export default {
                 filters: this.filters,
                 intervals: this.intervals,
                 params: this.params,
+                selectable: this.template.selectable,
                 selected: this.selected,
             };
 

--- a/src/resources/assets/js/components/enso/vuedatatable/topControls/SelectAll.vue
+++ b/src/resources/assets/js/components/enso/vuedatatable/topControls/SelectAll.vue
@@ -1,0 +1,36 @@
+<template>
+
+    <button class="button"
+        @click="toggle">
+        <span class="icon is-small">
+            <fa icon="check-square"/>
+        </span>
+    </button>
+
+</template>
+
+<script>
+
+  import { library } from '@fortawesome/fontawesome-svg-core';
+  import { faCheckSquare } from '@fortawesome/free-solid-svg-icons';
+
+  library.add(faCheckSquare);
+
+  export default {
+    name: 'SelectAll',
+
+    data() {
+        return {
+            state: false
+        }
+    },
+
+    methods: {
+      toggle() {
+          this.state = !this.state;
+          this.$emit('select-all', this.state)
+      },
+    },
+  };
+
+</script>


### PR DESCRIPTION
This is  a **feature**.

### Prerequisites
* [✅] Are you running the latest version?
* [✅] Are you reporting to the correct repository?
* [✅] Did you check the documentation?
* [✅] Did you perform a cursory search?

### Description
Hey!

This PR adds a select all button to the topControls and an `isSelected()` helper function to the Action class. 

The helper function was the best method I could think of for checking if selected in actions, I tried modifying the action to only loop through the selected data, however this seemed to have some adverse affects on performance (not so noticable for smaller data sets, but I was testing with 200k).

The select all button required me to make some modifications to the Builder, I needed to capture the filtered data before the `limit()` function is run, this also has some affects on performance when testing with 200k records, so for this reason I have gated the select all option behind `fullRecordInfo`, if this is not true the button will not show, and the `raw` property will not get populated.

You will notice I have removed the `selected` prop from TableBody and updated the select functions to directly modify the `$parent.selected`. The reason I have done this is I was getting some unexpected results when hooking into the `update-selected` event within my application, i.e. I could select the first row in the table but the emitted array is empty. With this change everything is working great!

The final thing I have done is add `selected` to the export request data.

(hopefully the spacing/new lines are all correct in this!)
